### PR TITLE
Support Identifier as callee

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports.generate = generate;
 //    https://github.com/mathiasbynens/regenerate
 //    https://www.npmjs.com/package/regjsgen
 
-var regex = /^\s*([A-Za-z$_][A-Za-z0-9$_]*)\s*\.\s*([A-Za-z$_][A-Za-z0-9$_]*)\s*\(\s*((?:[A-Za-z$_][A-Za-z0-9$_]*)|(?:\[\s*[A-Za-z$_][A-Za-z0-9$_]*\s*]))?((?:\s*,\s*(?:(?:[A-Za-z$_][A-Za-z0-9$_]*)|(?:\[\s*[A-Za-z$_][A-Za-z0-9$_]*\s*])))+)?\s*\)\s*$/;
+var regex = /^\s*(?:([A-Za-z$_][A-Za-z0-9$_]*)\s*\.)?\s*([A-Za-z$_][A-Za-z0-9$_]*)\s*\(\s*((?:[A-Za-z$_][A-Za-z0-9$_]*)|(?:\[\s*[A-Za-z$_][A-Za-z0-9$_]*\s*]))?((?:\s*,\s*(?:(?:[A-Za-z$_][A-Za-z0-9$_]*)|(?:\[\s*[A-Za-z$_][A-Za-z0-9$_]*\s*])))+)?\s*\)\s*$/;
 
 function parse(str) {
 	var match = regex.exec(str);
@@ -44,22 +44,39 @@ function parse(str) {
 		});
 	});
 
+	var callee;
+	if (object) {
+		callee = {
+			object: object,
+			member: member
+		};
+	} else {
+		callee = {
+			identifier: member
+		};
+	}
 	return {
-		object: object,
-		member: member,
+		callee: callee,
 		args: trimmed
 	};
 }
 
 function generate(parsed) {
-	return [
-		parsed.object,
-		'.',
-		parsed.member,
+	var callee;
+	if (parsed.callee.object) {
+		callee = [
+			parsed.callee.object,
+			'.',
+			parsed.callee.member
+		];
+	} else {
+		callee = [parsed.callee.identifier];
+	}
+	return callee.concat([
 		'(',
 		parsed.args.map(function (arg) {
 			return arg.optional ? '[' + arg.name + ']' : arg.name;
 		}).join(', '),
 		')'
-	].join('');
+	]).join('');
 }

--- a/index.js
+++ b/index.js
@@ -23,12 +23,14 @@ function parse(str) {
 	var callee;
 	if (match[1]) {
 		callee = {
+			type: 'MemberExpression',
 			object: match[1],
 			member: match[2]
 		};
 	} else {
 		callee = {
-			identifier: match[2]
+			type: 'Identifier',
+			name: match[2]
 		};
 	}
 
@@ -62,14 +64,14 @@ function parse(str) {
 
 function generate(parsed) {
 	var callee;
-	if (parsed.callee.object) {
+	if (parsed.callee.type === 'MemberExpression') {
 		callee = [
 			parsed.callee.object,
 			'.',
 			parsed.callee.member
 		];
 	} else {
-		callee = [parsed.callee.identifier];
+		callee = [parsed.callee.name];
 	}
 	return callee.concat([
 		'(',

--- a/index.js
+++ b/index.js
@@ -20,8 +20,18 @@ function parse(str) {
 		return null;
 	}
 
-	var object = match[1];
-	var member = match[2];
+	var callee;
+	if (match[1]) {
+		callee = {
+			object: match[1],
+			member: match[2]
+		};
+	} else {
+		callee = {
+			identifier: match[2]
+		};
+	}
+
 	var args = match[4] || '';
 	args = args.split(',');
 	if (match[3]) {
@@ -44,17 +54,6 @@ function parse(str) {
 		});
 	});
 
-	var callee;
-	if (object) {
-		callee = {
-			object: object,
-			member: member
-		};
-	} else {
-		callee = {
-			identifier: member
-		};
-	}
 	return {
 		callee: callee,
 		args: trimmed

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ $ npm install --save call-signature
 ## Usage
 
 ```js
-const signature = require('call-signature');
+var signature = require('call-signature');
 
 // parse a call signature definition
 var parsed = signature.parse('t.equal(expected, actual, [message])');
@@ -21,8 +21,11 @@ var parsed = signature.parse('t.equal(expected, actual, [message])');
 console.log(parsed);
 /* =>  
        {
-         object: 't',
-         member: 'equal',
+         callee: {
+           type: 'MemberExpression',
+           object: 't',
+           member: 'equal'
+         },
          args: [
            {
              name: 'actual',
@@ -59,16 +62,32 @@ Type: `string`
 A string that matches the call signature spec:
 
 `object.member(required_arg1, required_arg2, [optional_arg1])`
+`name(required_arg1, required_arg2, [optional_arg1])`
 
-`object` and `member` can be any identifiers, but currently the callee must be a `MemberExpression` (that requirement may loosen in the future).
+`object`, `member` and `name` can be any identifiers, but currently the callee must be a `MemberExpression` or an `Identifier` (that requirement may loosen in the future).
  
 You can have any number of arguments. Optional arguments are denoted by placing the argument name between square `[`brackets`]`.
 
 #### returns
 
-A simple JS Object with three properties `object`, `member`, and `args`.
+A simple JS Object with three properties `callee` and `args`.
 
-`object` and `member` will be strings.
+`callee` will be an object containing `type` property and its corresponding properties.
+
+when matched against `MemberExpression` like `foo.bar(baz)`, `object` and `member` will be strings.
+
+    callee: {
+      type: 'MemberExpression',
+      object: 'foo',
+      member: 'bar'
+    }
+
+when matched against `Identifier` like `foo(baz)`, `name` will be string.
+
+    callee: {
+      type: 'Identifier',
+      name: 'foo'
+    }
 
 `args` will be an array. Each item of the array will have two properties `name`, and `optional`. 
  `name` will be the `string` name of the arg. `optional` will be a boolean value.

--- a/test.js
+++ b/test.js
@@ -4,6 +4,7 @@ import support from './';
 test('parse - handles spaces', t => {
 	const expected = {
 		callee: {
+			type: 'MemberExpression',
 			object: 't',
 			member: 'equal'
 		},
@@ -31,7 +32,8 @@ test('parse - handles spaces', t => {
 test('parse - when callee is an Identifier', t => {
 	const expected = {
 		callee: {
-			identifier: 'assert'
+			type: 'Identifier',
+			name: 'assert'
 		},
 		args: [
 			{
@@ -53,6 +55,7 @@ test('parse - when callee is an Identifier', t => {
 test('parse - handles no args', t => {
 	const expected = {
 		callee: {
+			type: 'MemberExpression',
 			object: 'a',
 			member: 'fail'
 		},
@@ -66,6 +69,7 @@ test('parse - handles no args', t => {
 test('parse - handles only optional args', t => {
 	const expected1 = {
 		callee: {
+			type: 'MemberExpression',
 			object: 'assert',
 			member: 'baz'
 		},
@@ -79,6 +83,7 @@ test('parse - handles only optional args', t => {
 
 	const expected2 = {
 		callee: {
+			type: 'MemberExpression',
 			object: 'assert',
 			member: 'baz'
 		},
@@ -104,6 +109,7 @@ test('parse - handles only optional args', t => {
 test('generate - MemberExpression callee', t => {
 	const parsed = {
 		callee: {
+			type: 'MemberExpression',
 			object: 't',
 			member: 'equal'
 		},
@@ -130,7 +136,8 @@ test('generate - MemberExpression callee', t => {
 test('generate - Identifier callee', t => {
 	const parsed = {
 		callee: {
-			identifier: 'assert'
+			type: 'Identifier',
+			name: 'assert'
 		},
 		args: [
 			{

--- a/test.js
+++ b/test.js
@@ -3,8 +3,10 @@ import support from './';
 
 test('parse - handles spaces', t => {
 	const expected = {
-		object: 't',
-		member: 'equal',
+		callee: {
+			object: 't',
+			member: 'equal'
+		},
 		args: [
 			{
 				name: 'actual',
@@ -26,10 +28,34 @@ test('parse - handles spaces', t => {
 	t.end();
 });
 
+test('parse - when callee is an Identifier', t => {
+	const expected = {
+		callee: {
+			identifier: 'assert'
+		},
+		args: [
+			{
+				name: 'value',
+				optional: false
+			},
+			{
+				name: 'message',
+				optional: true
+			}
+		]
+	};
+	t.same(support.parse('assert(value,[message])'), expected, 'no spaces');
+	t.same(support.parse('assert(value, [message])'), expected, 'standard spacing');
+	t.same(support.parse('  assert  (  value  ,  [  message  ]  )  '), expected, 'lots of spaces');
+	t.end();
+});
+
 test('parse - handles no args', t => {
 	const expected = {
-		object: 'a',
-		member: 'fail',
+		callee: {
+			object: 'a',
+			member: 'fail'
+		},
 		args: []
 	};
 	t.same(support.parse('a.fail()'), expected, 'no spaces');
@@ -39,8 +65,10 @@ test('parse - handles no args', t => {
 
 test('parse - handles only optional args', t => {
 	const expected1 = {
-		object: 'assert',
-		member: 'baz',
+		callee: {
+			object: 'assert',
+			member: 'baz'
+		},
 		args: [
 			{
 				name: 'foo',
@@ -50,8 +78,10 @@ test('parse - handles only optional args', t => {
 	};
 
 	const expected2 = {
-		object: 'assert',
-		member: 'baz',
+		callee: {
+			object: 'assert',
+			member: 'baz'
+		},
 		args: [
 			{
 				name: 'foo',
@@ -71,10 +101,12 @@ test('parse - handles only optional args', t => {
 	t.end();
 });
 
-test('generate', t => {
+test('generate - MemberExpression callee', t => {
 	const parsed = {
-		object: 't',
-		member: 'equal',
+		callee: {
+			object: 't',
+			member: 'equal'
+		},
 		args: [
 			{
 				name: 'actual',
@@ -95,8 +127,30 @@ test('generate', t => {
 	t.end();
 });
 
+test('generate - Identifier callee', t => {
+	const parsed = {
+		callee: {
+			identifier: 'assert'
+		},
+		args: [
+			{
+				name: 'value',
+				optional: false
+			},
+			{
+				name: 'message',
+				optional: true
+			}
+		]
+	};
+
+	t.is(support.generate(parsed), 'assert(value, [message])');
+	t.end();
+});
+
 test('parse->generate round trip', t => {
 	[
+		'assert(value, [message])',
 		't.ok(value, [message])',
 		't.notOk(value, [message])',
 		't.true(value, [message])',


### PR DESCRIPTION
Support `Identifier` as callee to match against `assert(value, [message])`
- [x] update regex
- [x] introduce `callee` property to make CallExpression like structure
- [x] implement generate side
- [x] introduce `type` property to `callee` to make much more CallExpression-like structure
